### PR TITLE
Master

### DIFF
--- a/constants.lua
+++ b/constants.lua
@@ -18,7 +18,8 @@ constants.led_blink_duration = {
 
 constants.pdu_sms_center_type = {
     domestic = "81",
-    global = "91"
+    global = "91",
+    alphanumeric = "D0"
 }
 
 constants.uart_ready_message = "UART_RECV_ID"


### PR DESCRIPTION
新增 对发件人（手机号）为英文的支持

此前版本在收到如`3HK`、`Spotify`等英文发件人的短信时，转发通知中的手机号是一串16进制字符串，这类消息的TP-OA的第二个字节为`D0`，即号码类型为Alphanumeric（字母数字），需要使用GSM 7-bit解码。



参考：[https://en.wikipedia.org/wiki/GSM_03.40#Addresses](https://en.wikipedia.org/wiki/GSM_03.40#Addresses)